### PR TITLE
Make compatible with Python2/3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='bucket_command_wrapper',
-    version='0.2.0',
+    version='0.3.0',
     description="""Wrapper to facilitate downloading / uploading files
       from buckets (i.e. S3) into containers (i.e. docker) and running an arbitrary command.
       """,


### PR DESCRIPTION
The object type returned by subprocess.call() changes from Python2 to Python3, and so we have to explicitly check the type after making the call. Not elegant.